### PR TITLE
Fix bg for patched separator

### DIFF
--- a/themes/srcery_patched.conf
+++ b/themes/srcery_patched.conf
@@ -27,12 +27,12 @@ xgray6=colour240
 # Left Status
 # #1 #2 ...
 left_status_1="#[fg=brightwhite,bg=$xgray4,bold] #S #[fg=$xgray4,bg=$xgray3,nobold,noitalics,nounderscore]"
-left_status_2="#[fg=brightwhite,bg=$xgray3] #I:#P #[fg=$xgray3,bg=black,nobold,noitalics,nounderscore]"
+left_status_2="#[fg=brightwhite,bg=$xgray3] #I:#P #[fg=$xgray3,bg=$xgray1,nobold,noitalics,nounderscore]"
 set -g status-left "$left_status_1$left_status_2"
 
 # Right Status
 # ... #3 #2 #1
-right_status_1="#[fg=$xgray3,bg=$xgray3,nobold,noitalics,nounderscore]#[fg=brightwhite,bg=$xgray4,bold] #(whoami)@#h"
+right_status_1="#[fg=$xgray4,bg=$xgray3,nobold,noitalics,nounderscore]#[fg=brightwhite,bg=$xgray4,bold] #(whoami)@#h"
 right_status_2="#[fg=$xgray3,bg=$xgray1,nobold,noitalics,nounderscore]#[fg=brightwhite,bg=$xgray3] %H:%M | %F"
 right_status_3="#[fg=brightwhite,bg=brightblack]#{prefix_highlight}"
 set -g status-right "$right_status_3$right_status_2 $right_status_1 "


### PR DESCRIPTION
For patched conf, right_status_1 separator is not visible. Also, visibility of left_status_2 separator depends on terminal color theme. (observed in c4d18ee)

![image](https://user-images.githubusercontent.com/15703757/74042490-f9d78180-4a0a-11ea-8596-8c753446b8aa.png)

![image](https://user-images.githubusercontent.com/15703757/74042519-09ef6100-4a0b-11ea-9271-4fd64011e67c.png)

This PR allows separators visible regardless of terminal color theme as below.

![image](https://user-images.githubusercontent.com/15703757/74040859-e70f7d80-4a07-11ea-93a7-b1f8475fb88b.png)

![image](https://user-images.githubusercontent.com/15703757/74042178-630ac500-4a0a-11ea-850e-8ecd4d1fa8cf.png)
