### PR TITLE
Increase copy-mode and alert legibility

### DIFF
--- a/themes/srcery.conf
+++ b/themes/srcery.conf
@@ -43,7 +43,7 @@ setw -g window-status-style fg=white,bg=default
 setw -g window-status-separator ""
 
 setw -g window-status-activity-style fg=brightwhite,bg=default
-setw -g window-status-bell-style fg=blue,bg=yellow
+setw -g window-status-bell-style fg=black,bg=yellow
 
 # Pane border
 setw -g pane-border-style fg=$xgray3,bg=default

--- a/themes/srcery.conf
+++ b/themes/srcery.conf
@@ -57,7 +57,7 @@ setw -g clock-mode-style 24
 set -g message-command-style fg=brightwhite,bg=brightblack
 
 # Mode Style
-setw -g mode-style fg=black,bold,bg=cyan
+setw -g mode-style fg=white,bold,bg=blue
 
 # Message
 set -g message-style fg=brightwhite,bg=$xgray4

--- a/themes/srcery_no_patched.conf
+++ b/themes/srcery_no_patched.conf
@@ -40,7 +40,7 @@ setw -g window-status-format " #I: #W (#F) "
 
 # Tmux Prefix
 set -g @prefix_highlight_copy_prompt "COPY"
-set -g @prefix_highlight_copy_mode_attr "fg=brightwhite,bg=cyan,bold"
+set -g @prefix_highlight_copy_mode_attr "fg=white,bold,bg=blue"
 
 # }}}
 

--- a/themes/srcery_patched.conf
+++ b/themes/srcery_patched.conf
@@ -56,7 +56,7 @@ setw -g window-status-format "$window_status_1$window_status_2$window_status_3"
 get_prefix="#(tmux show-option -gqv prefix | tr "[:lower:]" "[:upper:]" | sed 's/C-/\^/')"
 
 set -g @prefix_highlight_prefix_prompt "#[fg=brightwhite]#[bg=$brightorange]#[nobold]#[noitalics]#[nounderscore]#[fg=brightblack]#[bg=brightwhite]#[bold] $get_prefix"
-set -g @prefix_highlight_copy_prompt "#[fg=cyan]#[bg=colour208]#[nobold]#[noitalics]#[nounderscore]#[fg=black]#[bg=cyan]#[bold] COPY"
+set -g @prefix_highlight_copy_prompt "#[fg=blue]#[bg=colour208]#[nobold]#[noitalics]#[nounderscore]#[fg=white]#[bg=blue]#[bold] COPY"
 
 
 set -g @prefix_highlight_output_prefix "#[fg=colour208]#[bg=$xgray1]#[nobold]#[noitalics]#[nounderscore]"


### PR DESCRIPTION
I finally switched from my half-baked tmux theme to srcery-tmux, and great job on this, a really well made theme. I found some tweaks I'd like to suggest to improve readability a bit when in copy-mode:
![comparison](https://user-images.githubusercontent.com/4509009/94343676-051f0200-001a-11eb-90ed-55d7ec89899f.png)
